### PR TITLE
Feat/card info

### DIFF
--- a/src/components/CardInfo/CardInfo.css
+++ b/src/components/CardInfo/CardInfo.css
@@ -1,0 +1,23 @@
+.cards-info {
+    padding: 5rem;
+    border-radius: 0 0 50px 0;
+
+    h2 {
+        font-size: 4rem;
+        margin: 2rem auto;
+        color: var(--title-color);
+        font-weight: 500;
+    }
+
+    p {
+        text-wrap: wrap;
+        font-size: 2rem;
+        color: var(--color-light);
+        margin-bottom: 2rem;
+        font-weight: 300;
+    }
+
+    h2, p {
+        margin-left: 5rem;
+    }
+}

--- a/src/components/CardInfo/CardInfo.css
+++ b/src/components/CardInfo/CardInfo.css
@@ -6,18 +6,41 @@
         font-size: 4rem;
         margin: 2rem auto;
         color: var(--title-color);
-        font-weight: 500;
+        font-weight: 600;
     }
 
     p {
-        text-wrap: wrap;
         font-size: 2rem;
         color: var(--color-light);
         margin-bottom: 2rem;
-        font-weight: 300;
+        font-weight: 400;
     }
 
     h2, p {
         margin-left: 5rem;
     }
 }
+
+/* Mobile */
+@media only screen and (max-width: 1200px) {
+
+    .cards-info {
+        padding: 2rem;
+
+        h2 {
+            font-size: 2rem;
+            margin-top: 5rem;
+        }
+
+        p {
+            font-size: 1.5rem;
+            margin-bottom: 2rem;
+        }
+    
+        h2, p {
+            margin-left: 0;
+        }
+    }
+}
+
+/* Mobile */

--- a/src/components/CardInfo/CardInfo.jsx
+++ b/src/components/CardInfo/CardInfo.jsx
@@ -1,0 +1,12 @@
+import "./CardInfo.css";
+
+export default function CardInfo({ id, backgroundColor, title, description }) {
+  return (
+    <>
+        <div id={id} className="cards-info" style={{ backgroundColor: backgroundColor }}>
+            <h2>{title}</h2>
+            <p>{description}</p>
+        </div>
+    </>
+  );
+}

--- a/src/pages/Wiki/Wiki.css
+++ b/src/pages/Wiki/Wiki.css
@@ -1,0 +1,25 @@
+/* Seção Nossa História */
+
+.container-info {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    margin: 3rem auto;
+}
+
+#dark-blue {
+    z-index: 2;
+}
+
+#red {
+    z-index: 1;
+}
+
+#light-blue {
+    z-index: 0;
+}
+
+#dark-blue, #red, #light-blue {
+    margin-left: -5rem;
+}
+
+/* Fim Seção Nossa História */

--- a/src/pages/Wiki/Wiki.css
+++ b/src/pages/Wiki/Wiki.css
@@ -23,3 +23,28 @@
 }
 
 /* Fim Seção Nossa História */
+
+/* Mobile */
+@media only screen and (max-width: 1200px) {
+
+    /* Seção Nossa História */
+    .container-info {
+        grid-template-columns: 1fr;
+    }
+
+    #dark-blue, #red, #light-blue {
+        margin-left: 0;
+    }
+
+    #red, #light-blue {
+        margin-top: -5rem;
+    }
+
+    .title-dark-blue {
+        margin-top: 10rem;
+    }
+
+    /* Fim Seção Nossa História */
+}
+
+/* Mobile */

--- a/src/pages/Wiki/Wiki.jsx
+++ b/src/pages/Wiki/Wiki.jsx
@@ -1,7 +1,31 @@
+import "./Wiki.css";
+
+import CardInfo from "../../components/CardInfo/CardInfo";
+
 export default function Wiki() {
   return (
     <>
       <h1>Wiki</h1>
+      <div className="container-info">
+        <CardInfo 
+          id="dark-blue"
+          backgroundColor="var(--color-secondary)"
+          title="O Início de Tudo"
+          description="A Fórmula E, iniciada em 2014, é uma série de corridas de carros elétricos criada para promover a mobilidade sustentável e acelerar a adoção de veículos elétricos. A ideia foi desenvolvida por Jean Todt, da FIA, e Alejandro Agag em 2011. A primeira temporada contou com dez equipes e corridas em várias cidades globais."
+        />
+        <CardInfo
+          id="red" 
+          backgroundColor="var(--color-tertiary)"
+          title="Modernização"
+          description="Os carros eram inicialmente idênticos, mas a partir da segunda temporada, as equipes começaram a desenvolver seus próprios sistemas de propulsão. Em 2018, o carro Gen2 foi introduzido, eliminando a necessidade de trocas de carro durante as corridas. A Fórmula E também se destaca por sua interação com os fãs através do 'FanBoost'."
+        />
+        <CardInfo 
+          id="light-blue"
+          backgroundColor="var(--color-primary)"
+          title="Consolidação"
+          description="Grandes fabricantes como Audi, BMW, Mercedes-Benz, Jaguar e Porsche participam da competição. Em 2020, a Fórmula E foi reconhecida como um Campeonato Mundial pela FIA, consolidando seu prestígio. A série continua a ser uma plataforma para a inovação tecnológica e a sustentabilidade no automobilismo, promovendo um futuro mais verde."
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
# Cards infos

**Cards-Infos** componentizados e já adicionados à página **Wiki.**
Houve a necessidade de criar um arquivo `Wiki.css` para usar o _container_ pai para ajustar o efeito de cada _div_.

## Desktop

![image](https://github.com/user-attachments/assets/4f9357de-a126-4479-b2ac-7cfdd8dafc9a)

## Mobile - Smartphone

![image](https://github.com/user-attachments/assets/bf11644a-fdb1-44c9-8b62-2f950d0c7df6)

## Mobile - Tablet

![image](https://github.com/user-attachments/assets/01e68414-6fe3-41cd-9109-a0992b4b7b06)
